### PR TITLE
Fix remapping of records

### DIFF
--- a/src/main/java/org/cadixdev/mercury/Mercury.java
+++ b/src/main/java/org/cadixdev/mercury/Mercury.java
@@ -190,7 +190,7 @@ public final class Mercury {
     }
 
     private void run() throws Exception {
-        ASTParser parser = ASTParser.newParser(AST.JLS10);
+        ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 
         // Set Java version
         Map<String, String> options = JavaCore.getOptions();

--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.TagElement;
@@ -429,6 +430,12 @@ class RemapperVisitor extends SimpleRemapperVisitor {
     }
 
     @Override
+    public boolean visit(RecordDeclaration node) {
+        pushImportContext(node.resolveBinding());
+        return true;
+    }
+
+    @Override
     public boolean visit(TypeDeclaration node) {
         pushImportContext(node.resolveBinding());
         return true;
@@ -446,6 +453,11 @@ class RemapperVisitor extends SimpleRemapperVisitor {
 
     @Override
     public void endVisit(EnumDeclaration node) {
+        this.importStack.pop();
+    }
+
+    @Override
+    public void endVisit(RecordDeclaration node) {
         this.importStack.pop();
     }
 


### PR DESCRIPTION
This change has been in [Paper's fork](https://github.com/PaperMC/Mercury/commit/efe6d0b6569998a31ec16c6b20f16aabd5593a97) for quite some time, and upstream doesn't seem to want to merge it (PR 46 on CadixDev/Mercury)

May close https://github.com/FabricMC/fabric-loom/issues/405 in combination with
```java
mercury.setSourceCompatibility(JavaCore.VERSION_17);
```
in loom, or changing the default source compatibility in Mercury.