### PR TITLE
Add missing break for IBinding.PACKAGE

### DIFF
--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -191,6 +191,7 @@ class RemapperVisitor extends SimpleRemapperVisitor {
                 // This is ignored because it should be covered by separate handling
                 // of QualifiedName (for full-qualified class references),
                 // PackageDeclaration and ImportDeclaration
+                break;
             default:
                 throw new IllegalStateException("Unhandled binding: " + binding.getClass().getSimpleName() + " (" + binding.getKind() + ')');
         }


### PR DESCRIPTION
Based on the comment it seems like a break is wanted, not an exception. Resolves https://github.com/FabricMC/fabric-loom/issues/775

While this PR resolves the aforementioned issue, it seems that allowing the remap to continue uncovered another, less severe, issue:
![image](https://user-images.githubusercontent.com/11360596/212773415-e2a1f091-2a07-4802-a9ba-039dce3a5dce.png)
original code:
```java

    /**
     * Create a new {@link Builder}.
     *
     * @param name Name of the argument
     * @param <C>  Command sender type
     * @return Created builder
     * @since 1.5.0
     */
    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
        return new Builder<>(name);
    }
```
(https://github.com/Incendo/cloud/blob/487067b4e84864b364f6af49bcce6cf1718c2b07/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java, Mojang mapped)

intermediary mapped (where issue seems to be introduced)
```java

    /**
     * Create a new {@link cloud.commandframework.fabric.argument.AngleArgument.Builder}.
     *
     * @param name Name of the argument
     * @param <C>  Command sender type
     * @return Created builder
     * @since 1.5.0
     */
    public static <C> @NonNull cloud.commandframework.fabric.argument.AngleArgument.Builder<C> builder(final @NonNull String name) {
        return new cloud.commandframework.fabric.argument.AngleArgument.Builder<>(name);
    }
```

(needs to be `cloud.commandframework.fabric.argument.AngleArgument.@NonNull Builder<C>`, `AngleArgument.@NonNull Builder<C>`, or `@NonNull Builder<C>`.)

While a little annoying, this issue is a lot less severe than remap not working at all. So I think it's fine to address this at a future time.