### PR TITLE
Skip trying to remap module names

### DIFF
--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -191,6 +191,8 @@ class RemapperVisitor extends SimpleRemapperVisitor {
                 // This is ignored because it should be covered by separate handling
                 // of QualifiedName (for full-qualified class references),
                 // PackageDeclaration and ImportDeclaration
+            case IBinding.MODULE:
+                // We don't remap module names
                 break;
             default:
                 throw new IllegalStateException("Unhandled binding: " + binding.getClass().getSimpleName() + " (" + binding.getKind() + ')');


### PR DESCRIPTION
Fixes errors when depending on a library that has a `module-info.java` with loom